### PR TITLE
fix crash under Android 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("com.neovisionaries:nv-websocket-client:2.9")
 
     // Http utils to manipulate URL properly
-    implementation("org.apache.httpcomponents:httpclient:4.5.11")
+    implementation("cz.msebera.android:httpclient:4.5.8")
 
     // JSON handling
     implementation("com.github.openjson:openjson:1.0.11")

--- a/src/main/kotlin/ch/kuon/phoenix/Socket.kt
+++ b/src/main/kotlin/ch/kuon/phoenix/Socket.kt
@@ -5,7 +5,8 @@ import java.util.Timer
 import com.github.openjson.JSONObject
 import com.github.openjson.JSONArray
 import com.neovisionaries.ws.client.*
-import org.apache.http.client.utils.URIBuilder
+import cz.msebera.android.httpclient.client.utils.URIBuilder
+
 import kotlin.math.min
 import kotlin.concurrent.schedule
 


### PR DESCRIPTION
Google freeze apache:http-client after Android 6 and delete it on Android 9.

So on Android 9, this lib works.

But on Android 6 - 8, it will have duplicate http-client lib and the app will crash.

so to solve it just replace the http-client to "cz.msebera.android:httpclient:4.5.8"